### PR TITLE
MAINT: update CheckM version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,12 @@ test-cov: all
 
 install: all
 	bash install-pplacer.sh
-	pip install git+https://github.com/misialq/CheckM.git@29916b666ba8834d0191d631110ffbdf4494cac9
+	pip install git+https://github.com/Ecogenomics/CheckM.git@8b42a8ca13dda3a967e2247efe6032f9df1bd434
 	$(PYTHON) setup.py install
 
 dev: all
 	bash install-pplacer.sh
-	pip install pre-commit pip install git+https://github.com/misialq/CheckM.git@29916b666ba8834d0191d631110ffbdf4494cac9
+	pip install pre-commit git+https://github.com/Ecogenomics/CheckM.git@8b42a8ca13dda3a967e2247efe6032f9df1bd434
 	pip install -e .
 	pre-commit install
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 
 QIIME 2 plugin for assessing the quality of (meta)genomes using CheckM.
 
-Notes on CheckM compatibility:
+Notes on CheckM version:
 CheckM version currently used by q2-checkm is pinned to a specific commit:
-https://github.com/misialq/CheckM.git@29916b666ba8834d0191d631110ffbdf4494cac9.
-This is required to make it compatible with the most recent QIIME 2 version
-which uses Python 3.8.
+https://github.com/Ecogenomics/CheckM.git@8b42a8ca13dda3a967e2247efe6032f9df1bd434.
+We are not using the corresponding version available through conda, as it has _pplacer_
+as a pinned dependency (and this dependency cannot be resolved on some systems).
+Instead, we are manually taking care of checkm's dependencies and just installing
+it through pip.


### PR DESCRIPTION
This PR updates the commit hash of the CheckM version to the latest one, which is now compatible with python 3.8.

We are still not using the version available through conda as it depends on _pplacer_ which is not available for all systems on conda.