### PR TITLE
MAINT: pin Altair to <5

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - python {{ python }}
     - setuptools
   run:
-    - altair
+    - altair <5.0.0
     - dendropy
     - hmmer
     - matplotlib


### PR DESCRIPTION
This PR pins Altair to version <5 - there were some significant changes that need review before we can use v5.